### PR TITLE
Add Bedrock provider and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ FORWARDED_ALLOW_IPS='*'
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+# Vector DB
+VECTOR_DB=pgvector
+# RAG reranker model
+RAG_RERANK_MODEL=claude-rerank
+

--- a/README.md
+++ b/README.md
@@ -238,6 +238,27 @@ If you are running Open WebUI in an offline environment, you can set the `HF_HUB
 export HF_HUB_OFFLINE=1
 ```
 
+### Amazon Bedrock Integration
+
+Open WebUI can interact with Amazon Bedrock for chat completions and
+embeddings. Configure the following environment variables in your `.env`
+file:
+
+```bash
+BEDROCK_REGION=us-east-1
+BEDROCK_CHAT_MODEL=<model-id>
+BEDROCK_EMBED_MODEL=<model-id>
+
+# Optional reranker used by `scripts/rerank.py`
+RAG_RERANK_MODEL=claude-rerank
+
+# Default vector database
+VECTOR_DB=pgvector
+```
+
+The provided `scripts/rerank.py` exposes a small FastAPI service that
+leverages Bedrock to rerank search results.
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2194,6 +2194,7 @@ RAG_RERANKING_MODEL = PersistentConfig(
     "rag.reranking_model",
     os.environ.get("RAG_RERANKING_MODEL", ""),
 )
+RAG_RERANK_MODEL = os.environ.get("RAG_RERANK_MODEL", "claude-rerank")
 if RAG_RERANKING_MODEL.value != "":
     log.info(f"Reranking model set: {RAG_RERANKING_MODEL.value}")
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -564,3 +564,9 @@ PIP_PACKAGE_INDEX_OPTIONS = os.getenv("PIP_PACKAGE_INDEX_OPTIONS", "").split()
 ####################################
 
 EXTERNAL_PWA_MANIFEST_URL = os.environ.get("EXTERNAL_PWA_MANIFEST_URL")
+
+# Amazon Bedrock
+BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-east-1")
+BEDROCK_CHAT_MODEL = os.environ.get("BEDROCK_CHAT_MODEL", "")
+BEDROCK_EMBED_MODEL = os.environ.get("BEDROCK_EMBED_MODEL", "")
+

--- a/backend/open_webui/migrations/versions/d3b4827191aa_add_fts_semantic_search.py
+++ b/backend/open_webui/migrations/versions/d3b4827191aa_add_fts_semantic_search.py
@@ -1,0 +1,54 @@
+"""add fts_semantic_search function
+
+Revision ID: d3b4827191aa
+Revises: ca81bd47c050
+Create Date: 2024-09-01 00:00:00.000000
+"""
+
+from alembic import op
+from typing import Sequence, Union
+
+revision: str = "d3b4827191aa"
+down_revision: Union[str, None] = "ca81bd47c050"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+CREATE OR REPLACE FUNCTION fts_semantic_search(query_vec vector, query_text text, k integer DEFAULT 8)
+RETURNS TABLE(id text, text text, vmetadata jsonb, score float) AS $$
+    WITH vector_top AS (
+        SELECT id, text, vmetadata,
+               (vector <=> query_vec) AS v_dist,
+               ts_rank_cd(to_tsvector('simple', text), plainto_tsquery(query_text)) AS bm25
+        FROM document_chunk
+        ORDER BY vector <=> query_vec
+        LIMIT k
+    ),
+    bm25_top AS (
+        SELECT id, text, vmetadata,
+               (vector <=> query_vec) AS v_dist,
+               ts_rank_cd(to_tsvector('simple', text), plainto_tsquery(query_text)) AS bm25
+        FROM document_chunk
+        WHERE to_tsvector('simple', text) @@ plainto_tsquery(query_text)
+        ORDER BY bm25 DESC
+        LIMIT k
+    ),
+    merged AS (
+        SELECT * FROM vector_top
+        UNION ALL
+        SELECT * FROM bm25_top
+    )
+    SELECT id, text, vmetadata, (1 - v_dist) + bm25 AS score
+    FROM merged
+    ORDER BY score DESC
+    LIMIT k;
+$$ LANGUAGE SQL;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS fts_semantic_search(vector, text, integer);")

--- a/backend/open_webui/model_providers/bedrock.py
+++ b/backend/open_webui/model_providers/bedrock.py
@@ -1,0 +1,37 @@
+import os
+import json
+import boto3
+
+
+class BedrockClient:
+    """Simple Bedrock provider for chat and embeddings."""
+
+    def __init__(self, region=None, chat_model=None, embed_model=None):
+        self.region = region or os.environ.get("BEDROCK_REGION")
+        self.chat_model = chat_model or os.environ.get("BEDROCK_CHAT_MODEL")
+        self.embed_model = embed_model or os.environ.get("BEDROCK_EMBED_MODEL")
+        self.runtime = boto3.client("bedrock-runtime", region_name=self.region)
+
+    def chat(self, messages: list[dict], **params):
+        payload = {
+            "messages": messages,
+            **params,
+        }
+        response = self.runtime.invoke_model(
+            modelId=self.chat_model,
+            body=json.dumps(payload).encode(),
+            contentType="application/json",
+        )
+        return json.loads(response["body"].read())
+
+    def embeddings(self, input_texts: list[str], **params):
+        payload = {
+            "input": input_texts,
+            **params,
+        }
+        response = self.runtime.invoke_model(
+            modelId=self.embed_model,
+            body=json.dumps(payload).encode(),
+            contentType="application/json",
+        )
+        return json.loads(response["body"].read())

--- a/backend/vector_stores/postgres_pgvector.py
+++ b/backend/vector_stores/postgres_pgvector.py
@@ -1,0 +1,3 @@
+from open_webui.retrieval.vector.dbs.pgvector import PgvectorClient
+
+VectorStore = PgvectorClient

--- a/scripts/chroma_to_pg.py
+++ b/scripts/chroma_to_pg.py
@@ -1,0 +1,35 @@
+import logging
+
+from open_webui.retrieval.vector.dbs.pgvector import PgvectorClient
+from open_webui.retrieval.vector.dbs.chroma import ChromaClient
+
+
+log = logging.getLogger(__name__)
+
+
+def migrate():
+    chroma = ChromaClient()
+    pg = PgvectorClient()
+
+    # access underlying client to get collection names
+    collections = chroma.client.list_collections()
+    for name in collections:
+        col = chroma.client.get_collection(name=name)
+        data = col.get(include=["embeddings", "metadatas", "documents"])
+        items = []
+        for idx, cid in enumerate(data["ids"]):
+            items.append(
+                {
+                    "id": cid,
+                    "text": data["documents"][idx],
+                    "vector": data["embeddings"][idx],
+                    "metadata": data["metadatas"][idx],
+                }
+            )
+        if items:
+            log.info(f"Migrating {len(items)} items for collection {name}")
+            pg.upsert(name, items)
+
+
+if __name__ == "__main__":
+    migrate()

--- a/scripts/rerank.py
+++ b/scripts/rerank.py
@@ -1,0 +1,37 @@
+import json
+import os
+from fastapi import FastAPI
+from pydantic import BaseModel
+from open_webui.model_providers.bedrock import BedrockClient
+
+app = FastAPI()
+client = BedrockClient()
+
+
+class RerankRequest(BaseModel):
+    model: str = os.getenv("RAG_RERANK_MODEL", "claude-rerank")
+    query: str
+    documents: list[str]
+    top_n: int = 8
+
+
+@app.post("/v1/rerank")
+async def rerank(req: RerankRequest):
+    payload = {
+        "query": req.query,
+        "documents": req.documents[: req.top_n],
+        "top_n": req.top_n,
+    }
+    response = client.runtime.invoke_model(
+        modelId=req.model,
+        body=json.dumps(payload).encode(),
+        contentType="application/json",
+    )
+    data = json.loads(response["body"].read())
+    return {"results": data.get("results", [])}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add Amazon Bedrock client provider
- support Bedrock env vars in backend
- add migration for `fts_semantic_search`
- provide PGVector helper scripts
- document new configuration in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_685982dbf268832a803e4f4b6aced439